### PR TITLE
Make functional_opt actually opt

### DIFF
--- a/benches/perf_test.rs
+++ b/benches/perf_test.rs
@@ -19,7 +19,7 @@ fn functional(bench: &mut Bencher) {
 }
 
 fn functional_opt(bench: &mut Bencher) {
-    bench.iter(|| black_box(performance_test::compute_functional(2)));
+    bench.iter(|| black_box(performance_test::compute_functional_opt(2)));
 }
 
 fn recursive(bench: &mut Bencher) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,12 +13,7 @@ pub fn compute_functional(count: u8) -> u32 {
 }
 
 pub fn compute_functional_opt(count: u8) -> u32 {
-    let elements = (0..count).collect::<Vec<u8>>().iter()
-        .map(|_e| return_5()-1).collect::<Vec<u32>>();
-    let value = elements.iter()
-        .fold(0, |sum, val| (sum << 2) + (sum <<1) + val);
-
-    value
+    (0..count).map(|_e| return_5()-1).fold(0, |sum, val| (sum << 2) + (sum <<1) + val)
 }
 
 pub fn compute_imperative(count: u8) -> u32 {


### PR DESCRIPTION
It makes little sense to call 
```rust
(0..count).collect::<Vec<u8>>().iter()
```
when you already have something you can iterate over. It introduces unnecessary (and expensive) heap allocation, also it disallows some optimisations. 

